### PR TITLE
Mailmap::Map#each should return self when a block is given

### DIFF
--- a/lib/mailmap/map.rb
+++ b/lib/mailmap/map.rb
@@ -33,7 +33,7 @@ module Mailmap
     end
 
     def each
-      return enum_for(:each) unless block_given?
+      return enum_for unless block_given?
 
       @map.each do |commit_email, entries_by_commit_name|
         entries_by_commit_name.each do |commit_name, (proper_name, proper_email)|

--- a/lib/mailmap/map.rb
+++ b/lib/mailmap/map.rb
@@ -40,6 +40,7 @@ module Mailmap
           yield [proper_name, proper_email, commit_name, commit_email]
         end
       end
+      self
     end
 
     # Look up the person's canonical name and email address.

--- a/test/mailmap/map_test.rb
+++ b/test/mailmap/map_test.rb
@@ -15,7 +15,16 @@ module Mailmap
       end
     end
 
-    def test_each
+    def test_each_with_block_returns_self
+      mailmap = Map.parse('')
+      result = mailmap.each do
+        # Do nothing
+      end
+
+      assert_equal(result, mailmap)
+    end
+
+    def test_each_without_block_returns_enumerator
       mailmap = Map.parse(<<~MAILMAP)
         Joe R. Developer <joe@example.com>
         Jane Doe <jane@example.com> <jane@laptop.(none)>
@@ -26,6 +35,14 @@ module Mailmap
       assert_equal(['Joe R. Developer', nil, nil, 'joe@example.com'], enumerator.next)
       assert_equal(['Jane Doe', 'jane@example.com', nil, 'jane@laptop.(none)'], enumerator.next)
       assert_equal(['Jane Doe', 'jane@example.com', nil, 'jane@desktop.(none)'], enumerator.next)
+    end
+
+    def test_each_when_empty
+      mailmap = Map.parse('')
+      enumerator = mailmap.each
+
+      assert_instance_of(Enumerator, enumerator)
+      assert_raises(StopIteration) { enumerator.next }
     end
 
     def test_count


### PR DESCRIPTION
- Mailmap::Map#each should return self when block is given
- Remove redundant argument
